### PR TITLE
Make react-native-image-picker compatible with use_frameworks

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -4,8 +4,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <Photos/Photos.h>
 #import <PhotosUI/PhotosUI.h>
-
-@import MobileCoreServices;
+#import <MobileCoreServices/MobileCoreServices.h>
 
 @interface ImagePickerManager ()
 
@@ -67,12 +66,12 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 - (void)launchImagePicker:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback
 {
     self.callback = callback;
-    
+
     if (target == camera && [ImagePickerUtils isSimulator]) {
         self.callback(@[@{@"errorCode": errCameraUnavailable}]);
         return;
     }
-    
+
     self.options = options;
 
 #if __has_include(<PhotosUI/PHPicker.h>)
@@ -85,7 +84,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             picker.presentationController.delegate = self;
 
             if([self.options[@"includeExtra"] boolValue]) {
-                
+
                 [self checkPhotosPermissions:^(BOOL granted) {
                     if (!granted) {
                         self.callback(@[@{@"errorCode": errPermission}]);
@@ -96,7 +95,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             } else {
                 [self showPickerViewController:picker];
             }
-            
+
             return;
         }
     }
@@ -104,7 +103,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     UIImagePickerController *picker = [[UIImagePickerController alloc] init];
     [ImagePickerUtils setupPickerFromOptions:picker options:self.options target:target];
     picker.delegate = self;
-    
+
     if([self.options[@"includeExtra"] boolValue]) {
         [self checkPhotosPermissions:^(BOOL granted) {
             if (!granted) {
@@ -131,7 +130,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 NSData* extractImageData(UIImage* image){
     CFMutableDataRef imageData = CFDataCreateMutable(NULL, 0);
     CGImageDestinationRef destination = CGImageDestinationCreateWithData(imageData, kUTTypeJPEG, 1, NULL);
-    
+
     CFStringRef orientationKey[1];
     CFTypeRef   orientationValue[1];
     CGImagePropertyOrientation CGOrientation = CGImagePropertyOrientationForUIImageOrientation(image.imageOrientation);
@@ -141,11 +140,11 @@ NSData* extractImageData(UIImage* image){
 
     CFDictionaryRef imageProps = CFDictionaryCreate( NULL, (const void **)orientationKey, (const void **)orientationValue, 1,
                     &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    
+
     CGImageDestinationAddImage(destination, image.CGImage, imageProps);
-    
+
     CGImageDestinationFinalize(destination);
-    
+
     CFRelease(destination);
     CFRelease(orientationValue[0]);
     CFRelease(imageProps);
@@ -162,7 +161,7 @@ NSData* extractImageData(UIImage* image){
         }
         data = extractImageData(image);
     }
-    
+
     UIImage* newImage = image;
     if (![fileType isEqualToString:@"gif"]) {
         newImage = [ImagePickerUtils resizeImage:image
@@ -178,7 +177,7 @@ NSData* extractImageData(UIImage* image){
             data = UIImagePNGRepresentation(newImage);
         }
     }
-    
+
     NSMutableDictionary *asset = [[NSMutableDictionary alloc] init];
     asset[@"type"] = [@"image/" stringByAppendingString:fileType];
 
@@ -203,13 +202,13 @@ NSData* extractImageData(UIImage* image){
     asset[@"fileName"] = fileName;
     asset[@"width"] = @(newImage.size.width);
     asset[@"height"] = @(newImage.size.height);
-    
+
     if(phAsset){
         asset[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
         asset[@"id"] = phAsset.localIdentifier;
         // Add more extra data here ...
     }
-    
+
     return asset;
 }
 
@@ -236,10 +235,10 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
     if ((target == camera) && [self.options[@"saveToPhotos"] boolValue]) {
         UISaveVideoAtPathToSavedPhotosAlbum(url.path, nil, nil, nil);
     }
-    
+
     if (![url.URLByResolvingSymlinksInPath.path isEqualToString:videoDestinationURL.URLByResolvingSymlinksInPath.path]) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
-        
+
         // Delete file if it already exists
         if ([fileManager fileExistsAtPath:videoDestinationURL.path]) {
             [fileManager removeItemAtURL:videoDestinationURL error:nil];
@@ -259,25 +258,25 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
           }
         }
     }
-    
+
     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
-    
+
     if([self.options[@"formatAsMp4"] boolValue] && ![fileExtension isEqualToString:@"mp4"]) {
         NSURL *parentURL = [videoDestinationURL URLByDeletingLastPathComponent];
         NSString *path = [[parentURL.path stringByAppendingString:@"/"] stringByAppendingString:[[NSUUID UUID] UUIDString]];
         path = [path stringByAppendingString:@".mp4"];
         NSURL *outputURL = [NSURL fileURLWithPath:path];
-        
+
         [[NSFileManager defaultManager] removeItemAtURL:outputURL error:nil];
         AVURLAsset *asset = [AVURLAsset URLAssetWithURL:videoDestinationURL options:nil];
         AVAssetExportSession *exportSession = [[AVAssetExportSession alloc] initWithAsset:asset presetName:AVAssetExportPresetPassthrough];
-        
+
         exportSession.outputURL = outputURL;
         exportSession.outputFileType = AVFileTypeMPEG4;
         exportSession.shouldOptimizeForNetworkUse = YES;
-        
+
         dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-        
+
         [exportSession exportAsynchronouslyWithCompletionHandler:^(void) {
             if (exportSession.status == AVAssetExportSessionStatusCompleted) {
                 CGSize dimentions = [ImagePickerUtils getVideoDimensionsFromUrl:outputURL];
@@ -288,14 +287,14 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
                 response[@"fileSize"] = [ImagePickerUtils getFileSizeFromUrl:outputURL];
                 response[@"width"] = @(dimentions.width);
                 response[@"height"] = @(dimentions.height);
-                
+
                 dispatch_semaphore_signal(sem);
             } else if (exportSession.status == AVAssetExportSessionStatusFailed || exportSession.status == AVAssetExportSessionStatusCancelled) {
                 dispatch_semaphore_signal(sem);
             }
         }];
 
-        
+
         dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
     } else {
         CGSize dimentions = [ImagePickerUtils getVideoDimensionsFromUrl:videoDestinationURL];
@@ -306,7 +305,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         response[@"fileSize"] = [ImagePickerUtils getFileSizeFromUrl:videoDestinationURL];
         response[@"width"] = @(dimentions.width);
         response[@"height"] = @(dimentions.height);
-        
+
         if(phAsset){
             response[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
             response[@"id"] = phAsset.localIdentifier;
@@ -456,12 +455,12 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
 
         if ([info[UIImagePickerControllerMediaType] isEqualToString:(NSString *) kUTTypeImage]) {
             UIImage *image = [ImagePickerManager getUIImageFromInfo:info];
-            
+
             [assets addObject:[self mapImageToAsset:image data:[NSData dataWithContentsOfURL:[ImagePickerManager getNSURLFromInfo:info]] phAsset:asset]];
         } else {
             NSError *error;
             NSDictionary *videoAsset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] phAsset:asset error:&error];
-                        
+
             if (videoAsset == nil) {
                 NSString *errorMessage = error.localizedFailureReason;
                 if (errorMessage == nil) errorMessage = @"Video asset not found";
@@ -512,7 +511,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         return;
     }
     photoSelected = YES;
-    
+
     if (results.count == 0) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.callback(@[@{@"didCancel": @YES}]);
@@ -535,7 +534,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
             PHFetchResult* fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[result.assetIdentifier] options:nil];
             asset = fetchResult.firstObject;
         }
-        
+
         dispatch_group_enter(completionGroup);
 
         if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
@@ -549,7 +548,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
             [provider loadFileRepresentationForTypeIdentifier:identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
                 NSData *data = [[NSData alloc] initWithContentsOfURL:url];
                 UIImage *image = [[UIImage alloc] initWithData:data];
-                
+
                 assets[index] = [self mapImageToAsset:image data:data phAsset:asset];
                 dispatch_group_leave(completionGroup);
             }];

--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -104,6 +104,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     UIImagePickerController *picker = [[UIImagePickerController alloc] init];
     [ImagePickerUtils setupPickerFromOptions:picker options:self.options target:target];
     picker.delegate = self;
+    picker.presentationController.delegate = self;
     
     if([self.options[@"includeExtra"] boolValue]) {
         [self checkPhotosPermissions:^(BOOL granted) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-picker",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
   "main": "src/index.ts",

--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -14,26 +14,32 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/react-native-image-picker/react-native-image-picker.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m,mm}"
-  s.pod_target_xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-fcxx-modules' }
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+  s.frameworks             = "MobileCoreServices"
 
-    s.pod_target_xcconfig = {
-      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17'
-    }
-
-    s.compiler_flags  = folly_compiler_flags + ' -DRN_FABRIC_ENABLED -fmodules -fcxx-modules'
-
-    s.dependency "React"
-    s.dependency "React-RCTFabric" # This is for fabric component
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  if defined?(install_modules_dependencies) != nil
+    install_modules_dependencies(s)
   else
-    s.dependency "React-Core"
+
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+      folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
+      s.pod_target_xcconfig = {
+        'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17'
+      }
+
+      s.compiler_flags  = folly_compiler_flags + ' -DRN_FABRIC_ENABLED -fmodules -fcxx-modules'
+
+      s.dependency "React"
+      s.dependency "React-RCTFabric" # This is for fabric component
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    else
+      s.dependency "React-Core"
+    end
   end
 end

--- a/src/platforms/native.ts
+++ b/src/platforms/native.ts
@@ -26,7 +26,7 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
 // @ts-ignore We want to check whether __turboModuleProxy exitst, it may not
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
-const nativeImagePicler = isTurboModuleEnabled ?
+const nativeImagePicker = isTurboModuleEnabled ?
   require("./NativeImagePicker").default :
   NativeModules.ImagePicker;
 
@@ -35,7 +35,7 @@ export function camera(
   callback?: Callback,
 ): Promise<ImagePickerResponse> {
   return new Promise((resolve) => {
-    nativeImagePicler.launchCamera(
+    nativeImagePicker.launchCamera(
       {...DEFAULT_OPTIONS, ...options},
       (result: ImagePickerResponse) => {
         if (callback) callback(result);
@@ -50,7 +50,7 @@ export function imageLibrary(
   callback?: Callback,
 ): Promise<ImagePickerResponse> {
   return new Promise((resolve) => {
-    nativeImagePicler.launchImageLibrary(
+    nativeImagePicker.launchImageLibrary(
       {...DEFAULT_OPTIONS, ...options},
       (result: ImagePickerResponse) => {
         if (callback) callback(result);


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

react-native-image-picker is not compatible with React Native 0.72, when use_frameworks! is enabled.
It fails to load a module, because it is mixing Swift and Objective-C import styles

Given that React Native is a C++ project and Swift and C++ do not like each other, the current setup is dangerous and can break easily.
This PR updates the podspec introducing the `install_modules_dependencies` function when defined to relieve the burden of properly handling the React Native internals from the library.
It also adds the dependency to the Apple's MobileCoreServices, so that we ca import it using the proper Objective-C syntax.
And then uses the right syntax to import the module. 

## Test Plan (required)

The example app is on 0.71, so the test is limited.

You can run the test by:
```
cd example
yarn
cd ios
NO_FLIPPER=1 USE_FRAMEWORKS=static pod update hermes-engine --no-repo-update
open example.xcworkspace
```
and then build and run from Xcode. You'll see the app building successfully.

I also created a new app using React Native 0.72, installed the library with `yarn add react-native-image-picker` and run the same commands.
Before applying the patch in this PR, it was failing.
After the patch, it was building successfully.
